### PR TITLE
feat(security): Human Credential Issuance — mint ActorCredential for kind:'human' OrgMembers

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -658,6 +658,38 @@ governance (Phase 4) and dream-machine nightly integration (Phase 5).
      relying on it falling out of other checks, mirroring
      `applyApprovalTransition`'s equivalent explicit check. 209 tests total
      (up from 207), `tsc --strict` clean.
+   - **Human credential issuance — first slice delivered
+     (`docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`,
+     `src/control-plane/authorization/human-identity-attestation.ts`)**:
+     the human-issuance gap this Phase 2 entry names above as a hard
+     prerequisite now has a real primitive, not just a named gap.
+     `HumanIdentityAttestation` (a short-lived, signed statement from an
+     external attester that a human's identity has already been verified —
+     shaped to carry a Cognitum Slack `user_id` via `identityRef`, per
+     `cognitum-one/slack` ADR-0002/ADR-0015, though this module imports
+     nothing from that repo) + `mintHumanActorCredential` (verifies the
+     attestation, cross-checks it against the persisted OrgMember's own
+     `identityRef`, then mints via the SAME durable-issuer-key
+     `mintActorCredential` agent issuance already uses) is the human
+     analogue of this Phase 2 entry's own agent-issuance anchor
+     (`claims_accept-handoff` succeeding). `resolveVerifiedActor`
+     (`actor-credential.ts`) now authorizes a `kind: 'human'` actor
+     specifically when its credential carries the AgentDB-backed provenance
+     marker `mintHumanActorCredential` writes — every other `kind: 'human'`
+     credential (including one minted directly via the existing, unchanged
+     `mintActorCredential`) stays blocked exactly as this Phase 2 entry's
+     original decision locked down, confirmed by a regression test, not
+     assumed. Full pipeline confirmed end to end: a human OrgMember can now
+     actually call `applyApprovalTransition` to approve an issue, real
+     `radio-moe` signing/verification throughout. **Still open**: no
+     producer of a `HumanIdentityAttestation` exists yet — no login/
+     dashboard flow calls this new mint function, so this narrows Phase 2's
+     remaining prerequisite to "produce one signed statement" rather than
+     "solve human authentication from scratch"; `setInteractionProfileConsent`'s
+     residual `actor.id` forgery risk (§4's narrowed exception, above) is
+     unchanged, deliberately out of this slice's scope. 222 tests total (up
+     from 209), `tsc --strict` clean, verified against the real installed
+     `radio-moe@0.3.1` end to end.
 4. **Phase 3 — ruclip-metaharness**: build-time bench suite, `score`/`genome`
    gates against the ruClip codebase. **Amended 2026-09-01**: no longer
    includes a runtime bench suite, `redblue`, or `flywheel` — that scope moved

--- a/docs/design/ACTOR-IDENTITY-VERIFICATION.md
+++ b/docs/design/ACTOR-IDENTITY-VERIFICATION.md
@@ -281,6 +281,24 @@ succeeding — closing the residual `setInteractionProfileConsent` risk
 above is one of the things that issuance work will finish, not a separate
 follow-up.
 
+**UPDATE (2026-09-01): the human-issuance primitive named above as missing
+now exists — see `docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`.**
+`mintHumanActorCredential` mints a real `kind: 'human'` `ActorCredential`
+after independently verifying a signed `HumanIdentityAttestation` from an
+admitted external attester (the human analogue of this section's own
+`claims_accept-handoff` chaining for agents), and `resolveVerifiedActor`
+(§2 above) now authorizes a `kind: 'human'` actor whose credential carries
+that path's AgentDB provenance marker. This is a narrower claim than "the
+block is lifted": every `kind: 'human'` credential minted any other way —
+including a bare `mintActorCredential` call naming a human `orgMemberId` —
+remains blocked exactly as decided here, unchanged. What's still open: no
+producer of a `HumanIdentityAttestation` exists yet (no login/dashboard
+flow calls this new mint function) — that remains Phase 2's own work,
+narrowed by this slice to "produce one signed statement" rather than
+"solve human authentication from scratch." `setInteractionProfileConsent`'s
+residual risk (§5 item 5 below) is likewise still open, deliberately out of
+this slice's scope.
+
 ## 5. Retrofit — the four call sites
 
 Every function below drops its `actor: OrgMember` parameter for

--- a/docs/design/HUMAN-CREDENTIAL-ISSUANCE.md
+++ b/docs/design/HUMAN-CREDENTIAL-ISSUANCE.md
@@ -1,0 +1,251 @@
+# Human Credential Issuance
+
+Status: implemented (`b8648f7`'s follow-on — closes the gap
+`ACTOR-IDENTITY-VERIFICATION.md` §4 named and deliberately deferred:
+"Issuance for `kind: 'human'` OrgMembers — NOT solved here, named honestly
+rather than papered over.")
+
+This is the first concrete piece of what that document called a "hard
+prerequisite for Phase 2 (dashboard)... Phase 2's own design doc, when
+written, must solve human credential issuance as its first concern." It
+does not build Phase 2's dashboard or a login flow — it builds the
+*primitive* a login flow (or any other verified-identity source) needs to
+hand ruClip: a signed statement that lets ruClip mint a real
+`ActorCredential` for a `kind: 'human'` OrgMember, closing the residual
+`applyApprovalTransition`/`persistIssue` Guard C/heartbeat block for humans
+specifically who present one.
+
+## 0. What §4 actually blocked, restated precisely
+
+`resolveVerifiedActor` (`actor-credential.ts`) unconditionally rejected
+every `kind: 'human'` OrgMember, regardless of what credential was
+presented — not because a human's identity is inherently less verifiable
+than an agent's, but because **no issuance mechanism existed** for humans.
+Agents get theirs by chaining trust off a real, already-verified event
+(`claims_accept-handoff` succeeding, §4 of the original document). Humans
+had no equivalent event to chain off — "a genuine human-issuance path
+requires an actual login/authentication flow... that does not exist
+anywhere in ruClip today."
+
+This document supplies that equivalent event: **a signed attestation from
+an external system that has already verified the human's identity by some
+means outside ruClip's own scope.**
+
+## 1. Ground truth checked before designing this
+
+Per this repo's own established discipline (`ACTOR-IDENTITY-VERIFICATION.md`
+§0's own opening line — "grounded in how ruClip's functions are *actually*
+invoked... checked first, not assumed"), three things were read directly,
+not assumed:
+
+1. **`credential-issuer.ts`'s actual trust model.** `mintActorCredential` is
+   documented as "Pure signing — does not touch the AgentDB bridge and does
+   not itself check that `orgMemberId` exists or holds any claim; the
+   caller is responsible for only minting a credential for an identity it
+   has already established by some other real means." This means the
+   *security boundary* for agent issuance today is not "the signer checks
+   anything about the target" — it is "only code paths that establish a
+   real prior event (a successful `claims_accept-handoff`) are supposed to
+   call `mintActorCredential`." Nothing in `mintActorCredential` itself
+   enforces that discipline; it is an architectural convention, not a
+   runtime check. A human-issuance mechanism built the same way — "only
+   call the mint function after establishing identity by some real means" —
+   would inherit that same property: anyone who can call
+   `mintActorCredential` directly (i.e., anyone who holds the durable
+   issuer's private key) could, in principle, mint a `kind: 'human'`
+   credential with no attestation at all, exactly as they always could for
+   an agent's `orgMemberId`. That is unacceptable for the specific class of
+   action §4 named "block" for (authority on behalf of the company,
+   effects visible to other parties) — it would make "block" a policy that
+   is trivially bypassable by anyone with issuer-key access, not a real
+   gate. See §2 for how this design closes that gap structurally rather
+   than by convention alone.
+2. **`cognitum-one/comms`'s ADR-0009** ("Cognitum-verified AgentBBS
+   identity") is real, working prior art for the *shape* of this exact
+   problem in a sibling repo: Ed25519 signing, a Secret-Manager-held
+   attester seed, a single-use nonce. Read directly, not assumed similar.
+   Its actual wire format, though, is agentbbs-core's own `Credential` type
+   — a domain tag plus length-prefixed framing, built for AgentBBS room
+   identity, not for a ruClip `ActorCredential`. Reusing that type directly
+   would repeat the exact mistake `ACTOR-IDENTITY-VERIFICATION.md` §4
+   already flagged once (forcing `federation_bbs_human_join`'s
+   room-access token into a job — "this human controls this ruClip
+   `OrgMember` identity" — its real scope doesn't cover). This design reuses
+   ADR-0009's *strategy* (Ed25519 + durable key + single-use nonce), not
+   its byte contract, and reuses it via `radio-moe`'s
+   `AgentFrame`/`canonicalBytes`/`verifyFrame` — the SAME primitive
+   `actor-credential.ts` and `credential-issuer.ts` already use in this
+   repo, for the same "don't invent a second signing mechanism" reason §1
+   of the original design gave.
+3. **`cognitum-one/slack`'s identity resolution** (ADR-0002 "Identity &
+   per-user capabilities", ADR-0015 "identity resolution is a single
+   point"). Read directly: the real, shipped identity primitive there is a
+   Slack `user_id` (e.g. `U0BQJNHH7L3`) resolved server-side, via a
+   verified `@cognitum.one` mailbox (`users.info`, `users:read.email`
+   scope), to an `Employee` role — "every event carries the Slack `user`
+   id... a Slack workspace membership alone must never grant a
+   capability... every tool call needs an authorization decision
+   attributable to a person." That resolution is a real, already-built,
+   already-verified event, structurally the human analogue of
+   `claims_accept-handoff` for agents. This design's
+   `HumanIdentityAttestation.humanIdentityRef` is shaped to carry exactly
+   that value (e.g. `slack:U0BQJNHH7L3`), matching
+   `schema/org-member.ts`'s own existing comment on `identityRef`: "For
+   kind: 'human' — a claims/BBS identity string."
+
+   **ruClip stays ruvnet-only at the substrate regardless.** This module
+   imports no Slack SDK, no Firebase, nothing from `cognitum-one/slack` or
+   `cognitum-one/comms`. It only defines a contract — a signed JSON
+   statement — and verifies it. Whatever system produces a
+   `HumanIdentityAttestation` (a Cognitum-side service sitting in front of
+   `cognitum-one/slack`'s identity resolution is the natural first
+   producer, but the contract does not know or care) is entirely outside
+   this repo's own code, exactly the same separation
+   `federation_bbs_human_join` already keeps between AgentBBS room access
+   and this repo.
+
+## 2. The contract: `HumanIdentityAttestation`
+
+```typescript
+export interface HumanIdentityAttestation {
+  orgMemberId: string;
+  companyId: string;
+  /** The verified human identity this attestation vouches for — e.g. a
+   *  Cognitum Slack user id such as `slack:U0BQJNHH7L3`. MUST equal the
+   *  target OrgMember's own `identityRef`. */
+  humanIdentityRef: string;
+  issuedAt: string;   // ISO 8601
+  expiresAt: string;  // ISO 8601 — short TTL, default 15 min
+  nonce: string;      // single-use replay guard, own namespace
+  signature: string;  // radio-moe signFrame() signature (hex)
+  attesterPublicKeyDerHex: string; // which admitted attester key signed this
+}
+```
+
+Signed/verified via `attestationFrame()` — the exact same
+`AgentFrame`/`canonicalBytes`/`verifyFrame` discipline
+`actorCredentialFrame()` already established, kept in one place so signing
+and verification can never drift apart. Uses `kind: 'claim'` (radio-moe's
+real, closed `FrameKind` union) with a distinct `capabilityUsed` field
+(`ruclip.human-identity-attestation`) so an attestation frame and an
+`ActorCredential` frame can never be mistaken for one another even though
+both use the same `kind`.
+
+## 3. Verification: `verifyHumanIdentityAttestation`
+
+Mirrors `verifyActorCredential`'s own structure exactly (§2 of the original
+design), throwing `ActorIdentityVerificationError` on the first failure,
+before any AgentDB write:
+
+1. `expiresAt` must be in the future.
+2. `attesterPublicKeyDerHex` must be a member of a caller-supplied
+   `admittedAttesterKeys` set — an unrecognized attester is rejected even
+   if the signature over it verifies internally consistently.
+3. `radio-moe`'s real `verifyFrame` must return `true`.
+4. **Replay check**, own namespace (`ruclip-human-identity-attestations`,
+   separate from `ActorCredential`'s own `ruclip-actor-credentials`
+   namespace — an attestation and the credential it mints are two
+   different single-use artifacts): the nonce must not have been consumed
+   before, using the same `memory_store` `ttl` guard the original design
+   established for `ActorCredential`'s own nonce (§3 of the original
+   document) — a self-expiring record, no separate cleanup job needed.
+
+`admittedAttesterKeys` is resolved via `resolveAdmittedAttesterKeys`,
+mirroring `credential-issuer.ts`'s `resolveAdmittedIssuerKeys` in *shape*
+but deliberately different in *mechanism*: ruClip's own durable issuer
+keypair is something this repo mints credentials with (GCP Secret Manager,
+`credential-issuer.ts`); an attester keypair belongs to an EXTERNAL system
+that ruClip never holds the private half of — only the public key(s) it
+chooses to trust. The primary mechanism is an explicit, caller-supplied
+`ReadonlySet<string>` (whatever wires up a specific deployment passes the
+keys it trusts); a comma-separated `RUCLIP_HUMAN_ATTESTER_KEYS` env var is
+a convenience fallback, not a second secret-manager integration — there is
+no real GCP project of ruClip's own yet to provision one against
+(`ADR-0001` §9, same caveat `credential-issuer.ts`'s own header already
+notes for the issuer key).
+
+## 4. Minting: `mintHumanActorCredential` and the provenance-marker fix to §1's gap
+
+`mintHumanActorCredential(attestation, admittedAttesterKeys, opts?,
+issuerConfig?, config?)`:
+
+1. Calls `verifyHumanIdentityAttestation` (consumes the attestation's
+   nonce — single-use, like §3 above).
+2. Recalls the target `OrgMember` fresh from AgentDB (never trusts anything
+   about identity beyond what step 1 established).
+3. Rejects if the target does not exist.
+4. Rejects if the target's `kind !== 'human'` — this issuance path is
+   human-only by design, mirroring how agent issuance chains off an
+   agent-only event (`claims_accept-handoff`).
+5. Rejects if the target's own persisted `identityRef` does not equal the
+   attestation's `humanIdentityRef` — the binding check that stops an
+   attestation genuinely proving identity X from minting a credential for
+   an OrgMember record actually bound to a different identity Y (a
+   desynced/misconfigured record, or a real attestation for one's own
+   identity misapplied to a different `orgMemberId`).
+6. Only then calls `credential-issuer.ts`'s real `mintActorCredential` —
+   the exact same durable-issuer-key signing path agent issuance already
+   uses. No second signing mechanism.
+7. **Immediately writes an AgentDB provenance marker**, keyed by the
+   freshly-minted credential's own nonce:
+   `humanAttestedCredentialMarkerKey(companyId, credential.nonce)` in a
+   dedicated `ruclip-human-attested-credentials` namespace, TTL matched to
+   the credential's own expiry.
+
+Step 7 is the structural fix to the gap §1 point 1 identified: without it,
+"only call the human-mint function after a real attestation" would be pure
+caller discipline, exactly as fragile as it already is for agents — anyone
+holding the issuer's private key could still mint an unattested `kind:
+'human'` credential directly via `mintActorCredential`. The marker makes
+the human-issuance path's guarantee independently checkable at
+*verification* time, not just trusted at *mint* time: `resolveVerifiedActor`
+(`actor-credential.ts`) now requires this marker to be present, for the
+SPECIFIC credential nonce being verified, before authorizing a `kind:
+'human'` actor — a credential minted any other way (including a bare
+`mintActorCredential` call naming a human `orgMemberId`) has no marker and
+is rejected, exactly as before this slice. This is what "the block lifts
+only when a credential minted through this path is presented" means
+concretely, verified by the
+`REGRESSION: resolveVerifiedActor still blocks...` test in
+`tests/control-plane/human-identity-attestation.test.ts`, not assumed.
+
+## 5. What this closes vs. what remains open
+
+**Closes**: `applyApprovalTransition`, `persistIssue`'s Guard C, and
+`persistHeartbeatSchedule`'s authorization requirement can now all be
+satisfied by a `kind: 'human'` OrgMember, provided its credential was
+minted via `mintHumanActorCredential` after a real, verified attestation.
+Confirmed end to end (not just unit-level at `resolveVerifiedActor`) by the
+`FULL PIPELINE` tests in `tests/control-plane/human-identity-attestation.test.ts`,
+which drive a human actor through `applyApprovalTransition`'s real
+'approve' action.
+
+**Remains open, named not hidden** (unchanged from the original design's
+own §6, since none of it was this slice's job):
+
+- **No producer of `HumanIdentityAttestation` exists yet.** This document
+  and its code define the contract and the consumer (verification +
+  minting); an actual attester service — e.g. a small Cognitum-side
+  process sitting in front of `cognitum-one/slack`'s identity resolution,
+  holding its own Ed25519 keypair, that a Phase 2 dashboard/login flow
+  would call — is not built here. That is Phase 2's own remaining work,
+  narrowed by this slice to "produce one signed JSON statement," not
+  "solve human authentication from scratch."
+- `setInteractionProfileConsent`'s `actor.id` forgery risk (original §4's
+  narrowed exception) — still not retrofitted, per the team lead's explicit
+  scope for this slice (strictly self-referential, no other party
+  affected, low priority relative to the three authority-bearing sites).
+  Could now be closed the same way as the other three, using this same
+  attestation mechanism, as a genuine follow-up — not done here to keep
+  this slice's diff scoped to what was asked.
+- Credential/attestation *revocation* before natural expiry is still not
+  designed — the short (15 min) TTL on both artifacts bounds the exposure
+  window, same trade-off the original design accepted for `ActorCredential`
+  itself.
+- The admitted-attester-key resolution mechanism (`RUCLIP_HUMAN_ATTESTER_KEYS`
+  env var fallback) is a convenience default, not a production secret-
+  management story — a real deployment should pass `admittedKeys`
+  explicitly, sourced however that deployment manages its own trust
+  relationships (this is intentionally NOT prescribed here, mirroring how
+  ruClip does not prescribe which GCP project holds its own issuer secret
+  either).

--- a/src/control-plane/authorization/actor-credential.ts
+++ b/src/control-plane/authorization/actor-credential.ts
@@ -24,6 +24,16 @@
  * this specific mechanism, `package.json`'s `peerDependenciesMeta` marks it
  * `optional: false` — the notification channel's own, separate, best-effort
  * `radio-moe` usage is untouched and stays tolerant of it being absent.
+ *
+ * `kind: 'human'` OrgMembers — see `docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`
+ * and `human-identity-attestation.ts`: `resolveVerifiedActor` below now
+ * authorizes a `kind: 'human'` OrgMember, but ONLY when its credential
+ * carries the AgentDB-backed provenance marker that `mintHumanActorCredential`
+ * writes after independently verifying a `HumanIdentityAttestation` from an
+ * admitted external attester. Every other `kind: 'human'` credential —
+ * including one minted directly via this file's own sibling
+ * `mintActorCredential` — stays blocked, matching
+ * ACTOR-IDENTITY-VERIFICATION.md §4's original fail-closed default exactly.
  */
 import { recallOrgMember, type AgentDbAdapterConfig } from '../store/agentdb-adapter.js';
 import type { OrgMember } from '../schema/org-member.js';
@@ -144,6 +154,33 @@ function credentialNonceKey(companyId: string, nonce: string): string {
 }
 
 /**
+ * Provenance marker for a human-issued `ActorCredential` — see
+ * `docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`. `mintHumanActorCredential`
+ * (`human-identity-attestation.ts`) writes one of these, keyed by the
+ * FRESHLY-MINTED credential's own single-use nonce, immediately after it has
+ * verified a real `HumanIdentityAttestation` and minted the credential —
+ * never before, never for any other reason. `resolveVerifiedActor` below
+ * requires this marker to be present before authorizing a `kind: 'human'`
+ * OrgMember; a `kind: 'human'` credential minted any other way (there is no
+ * other sanctioned way — `mintActorCredential` alone never writes this
+ * marker) has no marker and stays blocked.
+ *
+ * Deliberately a SEPARATE namespace/key from `NONCE_NAMESPACE`'s own replay
+ * guard above — that guard tracks "has THIS credential been verified yet"
+ * (consumed by `verifyActorCredential`, single-use); this one tracks "was
+ * THIS credential's nonce ever blessed by the human-attestation path"
+ * (written once at mint time, read-only here, never consumed) — conflating
+ * the two would make the marker disappear the instant the credential is
+ * verified, which is exactly when `resolveVerifiedActor` needs to read it.
+ */
+export const HUMAN_ATTESTED_NAMESPACE = 'ruclip-human-attested-credentials';
+
+/** Exported so `human-identity-attestation.ts` can write the identical key this file reads — kept in one place, same discipline as `credentialNonceKey`/`actorCredentialFrame`. */
+export function humanAttestedCredentialMarkerKey(companyId: string, credentialNonce: string): string {
+  return `ruclip:company:${companyId}:human-attested-credential:${credentialNonce}`;
+}
+
+/**
  * Verifies `credential`, in order, throwing `ActorIdentityVerificationError`
  * on the first failure, before any AgentDB write (§2):
  *
@@ -232,6 +269,34 @@ export async function verifyActorCredential(
  * and `persistIssue` for the concrete resolution, and `docs/PLAN.md` §8 for
  * why this diverges from a literal reading of ACTOR-IDENTITY-VERIFICATION.md
  * §5 items 1-2.
+ *
+ * `kind: 'human'` handling — UPDATED, see `docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`:
+ * §4's original locked decision blocked EVERY `kind: 'human'` OrgMember
+ * unconditionally, because no issuance path existed for them at all —
+ * "block" was a fail-closed placeholder for a missing mechanism, not a
+ * permanent policy (§4: "not closed by verification ... blocking is a
+ * fail-closed placeholder, not a solution"). `human-identity-attestation.ts`
+ * now provides that mechanism: `mintHumanActorCredential` mints a
+ * `kind: 'human'` `ActorCredential` only after independently verifying a
+ * signed `HumanIdentityAttestation` from an admitted external attester (a
+ * Cognitum-side service that already confirmed the human's identity — e.g.
+ * a verified `@cognitum.one` Slack identity, ADR-0002/ADR-0015 in
+ * `cognitum-one/slack`), and — critically — is the ONLY code path that ever
+ * writes a `humanAttestedCredentialMarkerKey` provenance marker for that
+ * credential's nonce. A `kind: 'human'` `ActorCredential` minted any other
+ * way (e.g. a bare `mintActorCredential` call naming a human's
+ * `orgMemberId`, still possible for anyone holding the durable issuer key,
+ * exactly as it always was for agents) carries no such marker and is still
+ * blocked below — the fail-closed default is otherwise UNCHANGED, and stays
+ * the default for every `kind: 'human'` OrgMember whose credential wasn't
+ * minted through that specific path. This is what "the block lifts only
+ * when a credential minted through this path is presented" means
+ * concretely: not a kind check alone (that would trust any signed
+ * credential naming a human, which `mintActorCredential`'s own "pure
+ * signer, caller-discipline" trust model — see `credential-issuer.ts`'s
+ * header — cannot rule out on its own), but a positive, AgentDB-backed fact
+ * that this specific credential went through real attestation
+ * verification.
  */
 export async function resolveVerifiedActor(
   authorization: ActorAuthorization,
@@ -250,11 +315,24 @@ export async function resolveVerifiedActor(
     );
   }
   if (actor.kind === 'human') {
-    throw new ActorIdentityVerificationError(
-      `Human-issued ActorCredentials are not supported yet (ACTOR-IDENTITY-VERIFICATION.md §4 — blocked until ` +
-        `real human credential issuance ships in Phase 2) — OrgMember '${orgMemberId}' is kind 'human' and cannot ` +
-        'be authorized via ActorCredential today; there is no fallback path',
+    // Deliberately keyed off the CREDENTIAL's own nonce (not derived from
+    // orgMemberId/companyId alone) — the marker binds to this one specific,
+    // freshly-minted credential instance, matching how the credential's own
+    // replay guard above is scoped (§3), not to "this OrgMember has ever
+    // had a marker."
+    const attested = await callTool<{ found?: boolean }>(
+      'memory_retrieve',
+      { key: humanAttestedCredentialMarkerKey(companyId, authorization.credential.nonce), namespace: HUMAN_ATTESTED_NAMESPACE },
+      config,
     );
+    if (!attested.found) {
+      throw new ActorIdentityVerificationError(
+        `OrgMember '${orgMemberId}' is kind 'human' and this ActorCredential carries no human-attestation ` +
+          'provenance marker (docs/design/HUMAN-CREDENTIAL-ISSUANCE.md) — only a credential minted via ' +
+          "mintHumanActorCredential, after verifying a real HumanIdentityAttestation, can authorize a human " +
+          'actor; there is no other fallback path',
+      );
+    }
   }
   return actor;
 }

--- a/src/control-plane/authorization/human-identity-attestation.ts
+++ b/src/control-plane/authorization/human-identity-attestation.ts
@@ -1,0 +1,372 @@
+/**
+ * Human-issuance path for `ActorCredential` (ACTOR-IDENTITY-VERIFICATION.md
+ * §4's named gap, closed here per `docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`)
+ * — the missing half of `credential-issuer.ts`'s agent-issuance path.
+ *
+ * ruClip is ruvnet-only at the substrate (root `CLAUDE.md`, `package.json`'s
+ * own description) — this module imports no Slack SDK, no Firebase, no
+ * Cognitum-specific code. It defines one contract instead:
+ * `HumanIdentityAttestation`, a short-lived, signed statement that SOME
+ * outside system — one that already knows a human is verified — hands to
+ * ruClip. ruClip only ever verifies that statement's signature against a
+ * caller-supplied, pluggable set of admitted attester keys (mirroring
+ * `credential-issuer.ts`'s own `resolveAdmittedIssuerKeys`); it never learns
+ * or cares HOW the attester verified the human (Slack OAuth, SSO, a
+ * dashboard session — Phase 2's concern, not this module's).
+ *
+ * Concretely, the intended attester for Cognitum's own deployment is the
+ * `cognitum-one/slack` agent's identity resolution (ADR-0002 "Identity &
+ * per-user capabilities", ADR-0015 "identity resolution is a single
+ * point"): a Slack `user_id` (e.g. `U0BQJNHH7L3`) resolved, server-side, via
+ * a verified `@cognitum.one` mailbox to an `Employee` role. That resolution
+ * already happens entirely inside `cognitum-one/slack`'s own process; this
+ * module does not reach into it or reimplement it — it only defines the
+ * shape of the artifact that resolution would need to produce and hand to
+ * ruClip, and how ruClip verifies it. `OrgMember.identityRef`
+ * (`schema/org-member.ts`: "For kind: 'human' — a claims/BBS identity
+ * string") is exactly where that Slack user id (or equivalent verified
+ * human identity string) is expected to live for a `kind: 'human'`
+ * OrgMember — this module cross-checks the attestation's own asserted
+ * identity against that field before minting anything (see
+ * `mintHumanActorCredential` below).
+ *
+ * `cognitum-one/comms`'s ADR-0009 ("Cognitum-verified AgentBBS identity") is
+ * real prior art for the SHAPE of this problem — Ed25519 signing, a
+ * Secret-Manager-held seed, a single-use nonce — but its actual byte
+ * contract (agentbbs-core's own `Credential` type, a domain tag +
+ * length-prefixed frame) is a DIFFERENT wire format for a DIFFERENT purpose
+ * (AgentBBS room identity, not a ruClip `ActorCredential`). This module does
+ * NOT reuse that contract directly — doing so would repeat exactly the
+ * mistake ACTOR-IDENTITY-VERIFICATION.md §4 already flagged once for
+ * `federation_bbs_human_join`'s token (a real primitive forced into a job
+ * its real scope doesn't cover). It reuses only the same STRATEGY —
+ * Ed25519 + durable key + single-use nonce — via this repo's own already-
+ * established `radio-moe` `AgentFrame`/`canonicalBytes`/`verifyFrame`
+ * primitive (the exact same one `actor-credential.ts` and
+ * `credential-issuer.ts` already use), same discipline as the rest of this
+ * slice: reuse the real primitive already proven in this codebase, don't
+ * invent or borrow a second one.
+ */
+import { randomUUID } from 'node:crypto';
+import {
+  actorCredentialFrame,
+  ActorIdentityVerificationError,
+  humanAttestedCredentialMarkerKey,
+  HUMAN_ATTESTED_NAMESPACE,
+  type ActorCredential,
+} from './actor-credential.js';
+import { mintActorCredential, type IssuerKeyConfig } from './credential-issuer.js';
+import { recallOrgMember, type AgentDbAdapterConfig } from '../store/agentdb-adapter.js';
+import { assertSafeId, callTool } from '../store/bridge-client.js';
+
+const DEFAULT_TTL_SECONDS = 15 * 60; // matches ActorCredential's own default (§1) and federation_bbs_human_join's
+
+/**
+ * A short-lived, signed statement from an external attester: "the human
+ * behind `humanIdentityRef` is who they claim to be, and controls
+ * `orgMemberId` in `companyId`." ruClip never produces one of these itself
+ * — `mintHumanActorCredential` below only ever CONSUMES an already-signed
+ * attestation handed to it by the calling environment.
+ */
+export interface HumanIdentityAttestation {
+  orgMemberId: string;
+  companyId: string;
+  /**
+   * The verified human identity this attestation vouches for — e.g. a
+   * Cognitum Slack user id such as `slack:U0BQJNHH7L3`, resolved via a
+   * verified `@cognitum.one` mailbox (`cognitum-one/slack` ADR-0002/
+   * ADR-0015). MUST equal the target OrgMember's own `identityRef`
+   * (`schema/org-member.ts`) — checked in `mintHumanActorCredential`, not
+   * here, since that check needs the persisted OrgMember record.
+   */
+  humanIdentityRef: string;
+  /** ISO 8601. */
+  issuedAt: string;
+  /** ISO 8601 — short TTL, default 15 min (matches ActorCredential's own default). */
+  expiresAt: string;
+  /** Single-use replay guard — separate namespace from ActorCredential's own nonce (see the replay-guard note below). */
+  nonce: string;
+  /** radio-moe `signFrame()` signature (hex) over `attestationFrame(attestation)`. */
+  signature: string;
+  /** Which attester key produced `signature` — checked against `admittedAttesterKeys` before the signature itself is trusted, same discipline as `ActorCredential.issuerPublicKeyDerHex` (§2 of ACTOR-IDENTITY-VERIFICATION.md). */
+  attesterPublicKeyDerHex: string;
+}
+
+/**
+ * The exact frame shape signed/verified for a `HumanIdentityAttestation` —
+ * mirrors `actorCredentialFrame`'s own discipline (kept in one place so
+ * signing, done by whatever external attester produces one of these, and
+ * verification here can never drift apart). Uses `kind: 'claim'` (radio-moe's
+ * real, closed `FrameKind` union — confirmed by reading `dist/agent-frame.d.ts`
+ * directly, same as `actorCredentialFrame`'s own comment) with a distinct
+ * `capabilityUsed` so a `HumanIdentityAttestation` frame and an
+ * `ActorCredential` frame can never be confused for one another even though
+ * both use `kind: 'claim'`.
+ */
+export function attestationFrame(
+  attestation: Pick<
+    HumanIdentityAttestation,
+    'orgMemberId' | 'companyId' | 'humanIdentityRef' | 'issuedAt' | 'expiresAt' | 'nonce'
+  >,
+): Record<string, unknown> {
+  return {
+    requestId: attestation.nonce,
+    agentId: 'ruclip-human-attester',
+    step: 0,
+    kind: 'claim',
+    value: {
+      orgMemberId: attestation.orgMemberId,
+      companyId: attestation.companyId,
+      humanIdentityRef: attestation.humanIdentityRef,
+      issuedAt: attestation.issuedAt,
+      expiresAt: attestation.expiresAt,
+    },
+    confidence: 1,
+    uncertainty: 0,
+    dependencies: [],
+    capabilityUsed: 'ruclip.human-identity-attestation',
+    evidenceHashes: [],
+    cost: 0,
+  };
+}
+
+interface RadioMoeVerifyModule {
+  verifyFrame(frame: Record<string, unknown>, publicKeyDerHex: string): boolean;
+}
+
+/** Required, not optional — same fail-closed posture as actor-credential.ts's own loader. */
+async function loadRadioMoeRequired(): Promise<RadioMoeVerifyModule> {
+  try {
+    return (await import('radio-moe')) as unknown as RadioMoeVerifyModule;
+  } catch (err) {
+    const e = err as { code?: string; message?: string };
+    if (
+      e?.code === 'ERR_MODULE_NOT_FOUND' ||
+      e?.code === 'MODULE_NOT_FOUND' ||
+      /Cannot find (module|package)/i.test(String(e?.message))
+    ) {
+      throw new ActorIdentityVerificationError(
+        'radio-moe is required to verify a HumanIdentityAttestation but is not installed — refusing to mint a ' +
+          'human ActorCredential rather than silently trusting an unverified attestation',
+      );
+    }
+    throw err;
+  }
+}
+
+/** Deliberately separate from every other AgentDB/memory namespace this repo uses (mirrors NONCE_NAMESPACE's own rationale in actor-credential.ts §3). */
+const ATTESTATION_NONCE_NAMESPACE = 'ruclip-human-identity-attestations';
+
+function attestationNonceKey(companyId: string, nonce: string): string {
+  return `ruclip:company:${companyId}:human-attestation-nonce:${nonce}`;
+}
+
+/**
+ * The admitted set of external attester public keys — pluggable, mirroring
+ * `credential-issuer.ts`'s `resolveAdmittedIssuerKeys`, but deliberately a
+ * DIFFERENT mechanism: ruClip's own durable issuer keypair is something
+ * THIS repo mints credentials with (GCP Secret Manager, `credential-issuer.ts`);
+ * an attester keypair belongs to an EXTERNAL system (e.g. a Cognitum
+ * identity-attestation service) that ruClip never holds the private half
+ * of — ruClip only ever needs the public key(s) it's willing to trust. The
+ * primary mechanism is therefore an explicit, caller-supplied set (whatever
+ * wires up a specific deployment passes the keys it trusts); a
+ * comma-separated env-var fallback is provided for convenience/ops, not as
+ * a second secret-manager integration.
+ */
+export interface AttesterKeyConfig {
+  /** The primary, pluggable mechanism — pass the admitted attester public key(s) (DER SPKI, hex) directly. */
+  admittedKeys?: ReadonlySet<string>;
+  /** Overrides which env var `resolveAdmittedAttesterKeys` reads when `admittedKeys` is omitted. Defaults to RUCLIP_HUMAN_ATTESTER_KEYS. */
+  keysEnvVar?: string;
+}
+
+/**
+ * Resolves the admitted attester key set. Prefers an explicit
+ * `config.admittedKeys` (the pluggable mechanism a real deployment should
+ * use); falls back to parsing a comma-separated list of DER SPKI hex keys
+ * from an env var (default `RUCLIP_HUMAN_ATTESTER_KEYS`) for convenience.
+ * Throws — fails closed, same posture as every other part of this
+ * mechanism — rather than returning an empty set, which would make every
+ * attestation vacuously fail the membership check with a confusing error
+ * far from its real cause.
+ */
+export function resolveAdmittedAttesterKeys(config?: AttesterKeyConfig): ReadonlySet<string> {
+  if (config?.admittedKeys) {
+    if (config.admittedKeys.size === 0) {
+      throw new ActorIdentityVerificationError('resolveAdmittedAttesterKeys: config.admittedKeys is empty');
+    }
+    return config.admittedKeys;
+  }
+  const envVarName = config?.keysEnvVar ?? 'RUCLIP_HUMAN_ATTESTER_KEYS';
+  const raw = process.env[envVarName];
+  const keys = (raw ?? '')
+    .split(',')
+    .map((k) => k.trim())
+    .filter(Boolean);
+  if (keys.length === 0) {
+    throw new ActorIdentityVerificationError(
+      `No admitted human-identity attester keys configured: pass config.admittedKeys explicitly (the primary, ` +
+        `pluggable mechanism — see this file's header), or set ${envVarName} to a comma-separated list of DER ` +
+        'SPKI hex public keys',
+    );
+  }
+  return new Set(keys);
+}
+
+/**
+ * Verifies `attestation`, in order, throwing `ActorIdentityVerificationError`
+ * on the first failure, before any AgentDB write — mirrors
+ * `verifyActorCredential`'s own structure exactly (ACTOR-IDENTITY-
+ * VERIFICATION.md §2):
+ *
+ * 1. `expiresAt` must be in the future.
+ * 2. `attesterPublicKeyDerHex` must be a member of `admittedAttesterKeys` —
+ *    an unrecognized attester is rejected even if the signature over it
+ *    verifies internally consistently.
+ * 3. `radio-moe`'s real `verifyFrame` must return true.
+ * 4. Replay check: the attestation's own nonce must not have been consumed
+ *    before (separate namespace/key from `ActorCredential`'s own nonce
+ *    guard — an attestation and the credential it mints are two different
+ *    single-use artifacts).
+ *
+ * Returns `{orgMemberId, companyId, humanIdentityRef}` — the caller
+ * (`mintHumanActorCredential`) is responsible for cross-checking
+ * `humanIdentityRef` against the persisted OrgMember record before minting
+ * anything; this function only establishes that the attestation itself is
+ * genuine and unreplayed.
+ */
+export async function verifyHumanIdentityAttestation(
+  attestation: HumanIdentityAttestation,
+  admittedAttesterKeys: ReadonlySet<string>,
+  config?: AgentDbAdapterConfig,
+): Promise<{ orgMemberId: string; companyId: string; humanIdentityRef: string }> {
+  assertSafeId(attestation.orgMemberId, 'attestation.orgMemberId');
+  assertSafeId(attestation.companyId, 'attestation.companyId');
+  assertSafeId(attestation.nonce, 'attestation.nonce');
+
+  if (Date.parse(attestation.expiresAt) <= Date.now()) {
+    throw new ActorIdentityVerificationError(
+      `HumanIdentityAttestation for '${attestation.orgMemberId}' expired at ${attestation.expiresAt}`,
+    );
+  }
+  if (!admittedAttesterKeys.has(attestation.attesterPublicKeyDerHex)) {
+    throw new ActorIdentityVerificationError(
+      `HumanIdentityAttestation for '${attestation.orgMemberId}' was signed by an attester key that is not ` +
+        'admitted — a validly-signed attestation from an unrecognized attester is still rejected',
+    );
+  }
+
+  const radioMoe = await loadRadioMoeRequired();
+  const frame = { ...attestationFrame(attestation), signature: attestation.signature };
+  if (!radioMoe.verifyFrame(frame, attestation.attesterPublicKeyDerHex)) {
+    throw new ActorIdentityVerificationError(
+      `HumanIdentityAttestation for '${attestation.orgMemberId}' failed signature verification`,
+    );
+  }
+
+  const nonceKey = attestationNonceKey(attestation.companyId, attestation.nonce);
+  const existing = await callTool<{ found?: boolean }>(
+    'memory_retrieve',
+    { key: nonceKey, namespace: ATTESTATION_NONCE_NAMESPACE },
+    config,
+  );
+  if (existing.found) {
+    throw new ActorIdentityVerificationError(
+      `HumanIdentityAttestation for '${attestation.orgMemberId}' was already used (nonce replay)`,
+    );
+  }
+  const ttlSeconds = Math.max(1, Math.ceil((Date.parse(attestation.expiresAt) - Date.now()) / 1000));
+  await callTool(
+    'memory_store',
+    { key: nonceKey, value: true, ttl: ttlSeconds, namespace: ATTESTATION_NONCE_NAMESPACE },
+    config,
+  );
+
+  return { orgMemberId: attestation.orgMemberId, companyId: attestation.companyId, humanIdentityRef: attestation.humanIdentityRef };
+}
+
+/**
+ * The one function that "turns a verified attestation into a mint" (per the
+ * design brief): verifies `attestation` (consuming its nonce — see
+ * `verifyHumanIdentityAttestation`'s own single-use note), recalls the
+ * target OrgMember fresh from AgentDB (never trusts anything about identity
+ * beyond what `verifyHumanIdentityAttestation` itself established), and
+ * only then mints a real, signed `ActorCredential` via `credential-issuer.ts`'s
+ * `mintActorCredential` — the exact same durable-issuer-key signing path
+ * agent issuance already uses. Immediately after minting, writes the
+ * AgentDB provenance marker `resolveVerifiedActor` (`actor-credential.ts`)
+ * requires before it will authorize a `kind: 'human'` actor — this is the
+ * ONLY function in this codebase that ever writes that marker.
+ *
+ * Rejects, before minting anything:
+ * - the target OrgMember does not exist (no such `orgMemberId` in `companyId`);
+ * - the target OrgMember's `kind` is not `'human'` — this issuance path is
+ *   human-only by design (agents already have a real event to chain trust
+ *   off — `claims_accept-handoff`, §4 — and don't get interactively
+ *   attested);
+ * - the target OrgMember's own persisted `identityRef` does not equal the
+ *   attestation's `humanIdentityRef` — the binding check that stops an
+ *   attestation genuinely proving identity X from minting a credential for
+ *   an OrgMember record actually bound to a different identity Y (whether
+ *   through attacker tampering — already caught by signature verification
+ *   above — or a desynced/misconfigured OrgMember record).
+ *
+ * IMPORTANT — same single-use caveat as `verifyActorCredential`: call this
+ * at most once per `HumanIdentityAttestation`; its nonce is consumed on the
+ * first call.
+ */
+export async function mintHumanActorCredential(
+  attestation: HumanIdentityAttestation,
+  admittedAttesterKeys: ReadonlySet<string>,
+  opts?: { ttlSeconds?: number },
+  issuerConfig?: IssuerKeyConfig,
+  config?: AgentDbAdapterConfig,
+): Promise<ActorCredential> {
+  const { orgMemberId, companyId, humanIdentityRef } = await verifyHumanIdentityAttestation(
+    attestation,
+    admittedAttesterKeys,
+    config,
+  );
+
+  const target = await recallOrgMember(companyId, orgMemberId, config);
+  if (!target) {
+    throw new ActorIdentityVerificationError(
+      `Verified HumanIdentityAttestation names OrgMember '${orgMemberId}' in company '${companyId}' but no such ` +
+        'OrgMember is persisted',
+    );
+  }
+  if (target.kind !== 'human') {
+    throw new ActorIdentityVerificationError(
+      `mintHumanActorCredential: OrgMember '${orgMemberId}' has kind '${target.kind}', not 'human' — this ` +
+        'issuance path mints credentials for human actors only',
+    );
+  }
+  if (target.identityRef !== humanIdentityRef) {
+    throw new ActorIdentityVerificationError(
+      `mintHumanActorCredential: attestation asserts human identity '${humanIdentityRef}' but OrgMember ` +
+        `'${orgMemberId}' is persisted with identityRef '${target.identityRef}' — refusing to mint a credential ` +
+        'for a mismatched identity',
+    );
+  }
+
+  const credential = await mintActorCredential(orgMemberId, companyId, opts ?? { ttlSeconds: DEFAULT_TTL_SECONDS }, issuerConfig);
+
+  await callTool(
+    'memory_store',
+    {
+      key: humanAttestedCredentialMarkerKey(companyId, credential.nonce),
+      value: true,
+      ttl: Math.max(1, Math.ceil((Date.parse(credential.expiresAt) - Date.now()) / 1000)),
+      namespace: HUMAN_ATTESTED_NAMESPACE,
+    },
+    config,
+  );
+
+  return credential;
+}
+
+/** Convenience re-export so a caller wiring up a fresh attestation doesn't need a second `randomUUID` import. */
+export function generateAttestationNonce(): string {
+  return randomUUID();
+}

--- a/tests/control-plane/actor-identity-verification.test.ts
+++ b/tests/control-plane/actor-identity-verification.test.ts
@@ -3,10 +3,14 @@
  * design closes. Covers §7's required cases: a forged orgMemberId (tampered
  * post-signing) is rejected, an expired credential is rejected, a replayed
  * nonce is rejected, an unadmitted-but-validly-signed issuer key is
- * rejected, a kind:'human' OrgMember is refused with no fallback, and the
- * regression that matters most — the exact scenario security found (a
- * credential for a DIFFERENT orgMemberId than the one that submitted being
- * used to approve/reject) is now blocked.
+ * rejected, a kind:'human' OrgMember whose credential carries no
+ * human-attestation provenance marker is refused with no other fallback
+ * (docs/design/HUMAN-CREDENTIAL-ISSUANCE.md later added the ONE legitimate
+ * way to lift this — see tests/control-plane/human-identity-attestation.test.ts
+ * — everything else stays blocked exactly as this file originally proved),
+ * and the regression that matters most — the exact scenario security found
+ * (a credential for a DIFFERENT orgMemberId than the one that submitted
+ * being used to approve/reject) is now blocked.
  *
  * No live AgentDB/radio-moe network instance — mockBridge for the AgentDB
  * bridge, and the real `radio-moe` package (a real devDependency of this
@@ -147,13 +151,20 @@ test('resolveVerifiedActor recalls the fresh OrgMember and returns it for a kind
   assert.deepEqual(resolved, actor);
 });
 
-test('resolveVerifiedActor blocks a kind: "human" OrgMember with no fallback path — ACTOR-IDENTITY-VERIFICATION.md §4 locked decision', async () => {
-  const human = baseActor({ kind: 'human', id: 'om-human', identityRef: 'bbs:alice' });
-  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
-  const authorization = await credentialFor(human);
+test(
+  'resolveVerifiedActor blocks a kind: "human" OrgMember whose credential carries no human-attestation ' +
+    'provenance marker — ACTOR-IDENTITY-VERIFICATION.md §4\'s fail-closed default, UNCHANGED by ' +
+    'docs/design/HUMAN-CREDENTIAL-ISSUANCE.md (see tests/control-plane/human-identity-attestation.test.ts for the ' +
+    'now-legitimate path via mintHumanActorCredential, and the regression proving this exact test still passes ' +
+    'for anything that did not go through it)',
+  async () => {
+    const human = baseActor({ kind: 'human', id: 'om-human', identityRef: 'bbs:alice' });
+    const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+    const authorization = await credentialFor(human);
 
-  await assert.rejects(() => resolveVerifiedActor(authorization, config), ActorIdentityVerificationError);
-});
+    await assert.rejects(() => resolveVerifiedActor(authorization, config), ActorIdentityVerificationError);
+  },
+);
 
 test('resolveVerifiedActor rejects when the verified orgMemberId has no persisted OrgMember record', async () => {
   const actor = baseActor();

--- a/tests/control-plane/human-identity-attestation.test.ts
+++ b/tests/control-plane/human-identity-attestation.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Coverage for docs/design/HUMAN-CREDENTIAL-ISSUANCE.md — the human-issuance
+ * path for ActorCredential that ACTOR-IDENTITY-VERIFICATION.md §4 named as
+ * a gap and deferred to Phase 2. Covers: a forged attestation (tampered
+ * after signing) is rejected, a replayed attestation nonce is rejected, an
+ * expired attestation is rejected, an unadmitted-but-validly-signed attester
+ * key is rejected, an attestation for a `kind !== 'human'` OrgMember is
+ * rejected, an attestation whose `humanIdentityRef` does not match the
+ * target OrgMember's own persisted `identityRef` is rejected, and — the
+ * regression that matters most for this slice — a `kind: 'human'` OrgMember
+ * CAN now be authorized via `resolveVerifiedActor`/`applyApprovalTransition`
+ * when (and only when) its credential was minted through
+ * `mintHumanActorCredential`, while a bare `mintActorCredential` call naming
+ * the same human `orgMemberId` (no attestation, no provenance marker) is
+ * still blocked end to end — confirmed by actually calling
+ * `applyApprovalTransition`, not assumed.
+ *
+ * No live AgentDB/radio-moe network instance — mockBridge for the AgentDB
+ * bridge, the real `radio-moe` package for actual signing/verification,
+ * same discipline as tests/control-plane/actor-identity-verification.test.ts.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mockBridge } from '../support/mock-bridge.js';
+import {
+  credentialFor,
+  humanAttestationFor,
+  humanCredentialFor,
+  nonceMockHandlers,
+  testAdmittedAttesterKeys,
+  testIssuerConfig,
+  unadmittedAttesterPrivateKeyPem,
+} from '../support/actor-credential-fixture.js';
+import {
+  mintHumanActorCredential,
+  verifyHumanIdentityAttestation,
+} from '../../src/control-plane/authorization/human-identity-attestation.js';
+import { resolveVerifiedActor, ActorIdentityVerificationError } from '../../src/control-plane/authorization/actor-credential.js';
+import { applyApprovalTransition, persistIssue } from '../../src/control-plane/store/agentdb-adapter.js';
+import type { OrgMember } from '../../src/control-plane/schema/org-member.js';
+import type { Issue } from '../../src/control-plane/schema/issue.js';
+import type { ApprovalTransition } from '../../src/control-plane/schema/approval-transition.js';
+
+const now = '2026-09-01T00:00:00.000Z';
+const issueKeyStr = 'ruclip:company:co-1:goal:goal-1:issue:issue-1';
+
+function baseIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'issue-1',
+    goalId: 'goal-1',
+    parentId: null,
+    assigneeId: null,
+    title: 'Build login',
+    description: '',
+    status: 'open',
+    approvalState: 'draft',
+    budgetImpact: 0,
+    approvalTransitionRef: null,
+    createdAt: now,
+    updatedAt: now,
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+function baseTransition(overrides: Partial<ApprovalTransition> = {}): ApprovalTransition {
+  return {
+    id: 'transition-1',
+    issueId: 'issue-1',
+    action: 'submit',
+    fromState: 'draft',
+    toState: 'pending',
+    actorId: 'om-1',
+    reason: null,
+    createdAt: now,
+    witnessRef: null,
+    ...overrides,
+  };
+}
+
+/** A verified Cognitum human identity — see human-identity-attestation.ts's header (ADR-0002/ADR-0015 shape). */
+function humanMember(overrides: Partial<OrgMember> = {}): OrgMember {
+  return {
+    id: 'om-human',
+    companyId: 'co-1',
+    kind: 'human',
+    identityRef: 'slack:U0BQJNHH7L3',
+    role: 'Employee',
+    managerId: null,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function agentMember(overrides: Partial<OrgMember> = {}): OrgMember {
+  return {
+    id: 'om-agent',
+    companyId: 'co-1',
+    kind: 'agent',
+    identityRef: 'agent-team-name',
+    role: 'Engineer',
+    managerId: null,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function orgMemberRecall(member: OrgMember) {
+  return (args: Record<string, unknown>) =>
+    args.tier === 'semantic' && args.query === `ruclip:company:${member.companyId}:org-member:${member.id}`
+      ? { results: [{ key: args.query, value: JSON.stringify(member) }] }
+      : { results: [] };
+}
+
+// --- verifyHumanIdentityAttestation / mintHumanActorCredential: required cases ---
+
+test('mintHumanActorCredential mints a real ActorCredential for a validly-attested, unexpired, unreplayed human OrgMember', async () => {
+  const human = humanMember();
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(human);
+
+  const credential = await mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config);
+
+  assert.equal(credential.orgMemberId, 'om-human');
+  assert.equal(credential.companyId, 'co-1');
+  assert.ok(credential.signature.length > 0);
+});
+
+test('mintHumanActorCredential rejects a forged attestation — tampering the orgMemberId after signing breaks the signature', async () => {
+  const human = humanMember();
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(human);
+  const forged = { ...attestation, orgMemberId: 'om-victim' };
+
+  await assert.rejects(
+    () => mintHumanActorCredential(forged, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test('mintHumanActorCredential rejects an attestation signed by an unadmitted attester key, even though it is internally valid', async () => {
+  const human = humanMember();
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(human, { attesterPrivateKeyPem: unadmittedAttesterPrivateKeyPem });
+
+  await assert.rejects(
+    () => mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test('mintHumanActorCredential rejects an expired attestation', async () => {
+  const human = humanMember();
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(human, { ttlSeconds: -1 });
+
+  await assert.rejects(
+    () => mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test('verifyHumanIdentityAttestation rejects a replayed attestation nonce — the same attestation cannot be verified twice', async () => {
+  const human = humanMember();
+  const { config } = mockBridge({ ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(human);
+
+  await verifyHumanIdentityAttestation(attestation, testAdmittedAttesterKeys, config);
+  await assert.rejects(
+    () => verifyHumanIdentityAttestation(attestation, testAdmittedAttesterKeys, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test('mintHumanActorCredential rejects when the target OrgMember does not exist', async () => {
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': () => ({ results: [] }), ...nonceMockHandlers() });
+  const attestation = await humanAttestationFor(humanMember());
+
+  await assert.rejects(
+    () => mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test("mintHumanActorCredential rejects when the target OrgMember's kind is not 'human' — this issuance path is human-only", async () => {
+  const agent = agentMember({ id: 'om-agent' });
+  const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(agent), ...nonceMockHandlers() });
+  // Attestation names the agent's own id/identityRef — still rejected purely on kind.
+  const attestation = await humanAttestationFor({ id: agent.id, companyId: agent.companyId, identityRef: agent.identityRef });
+
+  await assert.rejects(
+    () => mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+    ActorIdentityVerificationError,
+  );
+});
+
+test(
+  "mintHumanActorCredential rejects when the attestation's humanIdentityRef does not match the target OrgMember's " +
+    'own persisted identityRef — an attestation genuinely proving identity X cannot mint a credential for an ' +
+    'OrgMember record actually bound to a different identity Y',
+  async () => {
+    // The real, persisted OrgMember is bound to a DIFFERENT verified identity
+    // than the one the (validly-signed, unexpired, unreplayed) attestation
+    // asserts — e.g. a desynced/misconfigured OrgMember record, or an
+    // attacker who holds a real attestation for their OWN identity trying to
+    // point it at someone else's orgMemberId.
+    const human = humanMember({ id: 'om-human', identityRef: 'slack:U-REAL-OWNER' });
+    const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+    const attestation = await humanAttestationFor(human, { humanIdentityRef: 'slack:U-ATTACKER' });
+
+    await assert.rejects(
+      () => mintHumanActorCredential(attestation, testAdmittedAttesterKeys, undefined, testIssuerConfig, config),
+      ActorIdentityVerificationError,
+    );
+  },
+);
+
+// --- resolveVerifiedActor: the block lifts ONLY for a credential minted through this path ---
+
+test(
+  'resolveVerifiedActor now authorizes a kind: "human" OrgMember whose credential was minted via ' +
+    'mintHumanActorCredential — the human-attestation provenance marker lifts the block',
+  async () => {
+    const human = humanMember();
+    const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+    const authorization = await humanCredentialFor(human, config);
+
+    const resolved = await resolveVerifiedActor(authorization, config);
+    assert.deepEqual(resolved, human);
+  },
+);
+
+test(
+  'REGRESSION: resolveVerifiedActor still blocks a kind: "human" OrgMember whose credential was minted DIRECTLY ' +
+    'via mintActorCredential (no attestation, no provenance marker) — the fail-closed default is unchanged for ' +
+    'every credential that did not go through the attestation path',
+  async () => {
+    const human = humanMember();
+    const { config } = mockBridge({ 'agentdb_hierarchical-recall': orgMemberRecall(human), ...nonceMockHandlers() });
+    const authorization = await credentialFor(human);
+
+    await assert.rejects(() => resolveVerifiedActor(authorization, config), ActorIdentityVerificationError);
+  },
+);
+
+// --- Full pipeline: a human OrgMember can now approve an issue ---
+
+function orgMemberKeyStr(companyId: string, id: string): string {
+  return `ruclip:company:${companyId}:org-member:${id}`;
+}
+
+function recallReturning(stored: Issue | null, ...activeMembers: OrgMember[]) {
+  const memberEntries = new Map(activeMembers.map((m) => [orgMemberKeyStr(m.companyId, m.id), m]));
+  return (args: Record<string, unknown>) => {
+    if (args.tier === 'working' && stored) {
+      return { results: [{ key: issueKeyStr, value: JSON.stringify(stored) }] };
+    }
+    if (args.tier === 'semantic') {
+      const member = memberEntries.get(args.query as string);
+      if (member) return { results: [{ key: args.query as string, value: JSON.stringify(member) }] };
+    }
+    return { results: [] };
+  };
+}
+
+function activeClaimFor(actor: OrgMember, issueId: string) {
+  return () => ({
+    success: true,
+    claims: [
+      {
+        issueId,
+        claimant:
+          actor.kind === 'agent'
+            ? { type: 'agent', agentId: actor.id, agentType: actor.role }
+            : { type: 'human', userId: actor.id, name: actor.role },
+        status: 'active',
+      },
+    ],
+  });
+}
+
+test(
+  'FULL PIPELINE: applyApprovalTransition lets a human OrgMember approve an issue when holding a credential ' +
+    'minted through mintHumanActorCredential — "give ruClip a way to mint a human ActorCredential ... so ' +
+    "kind: 'human' OrgMembers can approve issues\" confirmed end to end, not just at resolveVerifiedActor's own " +
+    'unit level',
+  async () => {
+    const submit = baseTransition({ id: 'transition-submit', actorId: 'om-submitter', fromState: 'draft', toState: 'pending' });
+    const pendingIssue = baseIssue({ approvalState: 'pending', approvalTransitionRef: 'transition-submit' });
+    const humanApprover = humanMember({ id: 'om-human-approver', identityRef: 'slack:U0BQJNHH7L3' });
+    const { calls, config } = mockBridge({
+      'agentdb_hierarchical-recall': recallReturning(pendingIssue, humanApprover),
+      'agentdb_hierarchical-store': () => ({ success: true }),
+      'agentdb_causal-edge': () => ({ success: true }),
+      'claims_accept-handoff': () => ({ success: true }),
+      'claims_list': activeClaimFor(humanApprover, 'issue-1'),
+      ...nonceMockHandlers(),
+    });
+
+    const result = await applyApprovalTransition(
+      'co-1',
+      pendingIssue,
+      'approve',
+      await humanCredentialFor(humanApprover, config),
+      submit,
+      {},
+      config,
+    );
+
+    assert.equal(result.issue.approvalState, 'approved');
+    assert.equal(result.transition.actorId, 'om-human-approver');
+
+    const approvedByEdge = calls.find(
+      (c) => c.toolName === 'agentdb_causal-edge' && c.args.relation === 'approved_by',
+    );
+    assert.ok(approvedByEdge, 'expected an approved_by causal edge for the human approver');
+    assert.equal(approvedByEdge!.args.targetId, 'entity:org-member:om-human-approver');
+  },
+);
+
+test(
+  'FULL PIPELINE, negative: applyApprovalTransition still refuses a human OrgMember presenting a credential ' +
+    'minted directly via mintActorCredential (bypassing the attestation path entirely) — the default block holds ' +
+    'through the whole orchestration function, not only at resolveVerifiedActor',
+  async () => {
+    const submit = baseTransition({ id: 'transition-submit', actorId: 'om-submitter', fromState: 'draft', toState: 'pending' });
+    const pendingIssue = baseIssue({ approvalState: 'pending', approvalTransitionRef: 'transition-submit' });
+    const humanApprover = humanMember({ id: 'om-human-approver', identityRef: 'slack:U0BQJNHH7L3' });
+    const { config } = mockBridge({
+      'agentdb_hierarchical-recall': recallReturning(pendingIssue, humanApprover),
+      'agentdb_hierarchical-store': () => ({ success: true }),
+      'agentdb_causal-edge': () => ({ success: true }),
+      'claims_accept-handoff': () => ({ success: true }),
+      'claims_list': activeClaimFor(humanApprover, 'issue-1'),
+      ...nonceMockHandlers(),
+    });
+
+    const forgedAuthorization = await credentialFor(humanApprover);
+    await assert.rejects(
+      () => applyApprovalTransition('co-1', pendingIssue, 'approve', forgedAuthorization, submit, {}, config),
+      ActorIdentityVerificationError,
+    );
+  },
+);
+
+// --- Confirms persistIssue's Guard C (the other named site) is equally reachable by a legitimately-attested human ---
+
+test(
+  "persistIssue's Guard C authorizes a human actor's already-verified credential threaded in as { actor } " +
+    '(the internal-caller shape applyApprovalTransition itself uses) once minted via mintHumanActorCredential',
+  async () => {
+    const humanApprover = humanMember({ id: 'om-human-approver' });
+    const stored = baseIssue({ approvalState: 'pending', approvalTransitionRef: 'transition-submit' });
+    const { config } = mockBridge({
+      'agentdb_hierarchical-recall': (args) => {
+        if (args.tier === 'working' && args.query === issueKeyStr) {
+          return { results: [{ key: args.query, value: JSON.stringify(stored) }] };
+        }
+        return orgMemberRecall(humanApprover)(args);
+      },
+      'agentdb_hierarchical-store': () => ({ success: true }),
+      'agentdb_causal-edge': () => ({ success: true }),
+      'claims_list': activeClaimFor(humanApprover, 'issue-1'),
+      ...nonceMockHandlers(),
+    });
+    const authorization = await humanCredentialFor(humanApprover, config);
+    const resolvedActor = await resolveVerifiedActor(authorization, config);
+
+    const approveTransition = baseTransition({
+      id: 'transition-approve',
+      action: 'approve',
+      fromState: 'pending',
+      toState: 'approved',
+      actorId: 'om-human-approver',
+    });
+    const nextIssue = baseIssue({ approvalState: 'approved', approvalTransitionRef: 'transition-approve' });
+
+    // Should not throw — the human actor is authorized end to end for Guard C too.
+    await persistIssue('co-1', nextIssue, undefined, approveTransition, { actor: resolvedActor }, config);
+  },
+);

--- a/tests/support/actor-credential-fixture.ts
+++ b/tests/support/actor-credential-fixture.ts
@@ -9,9 +9,17 @@
  * `verifyActorCredential`'s nonce-replay guard (§3) — `nonceMockHandlers`
  * below provides an in-memory implementation to merge into `mockBridge`.
  */
+import { createPrivateKey, createPublicKey, randomUUID, sign as edSign } from 'node:crypto';
 import { mintActorCredential, resolveAdmittedIssuerKeys, type IssuerKeyConfig } from '../../src/control-plane/authorization/credential-issuer.js';
 import type { ActorAuthorization } from '../../src/control-plane/authorization/actor-credential.js';
+import {
+  attestationFrame,
+  mintHumanActorCredential,
+  resolveAdmittedAttesterKeys,
+  type HumanIdentityAttestation,
+} from '../../src/control-plane/authorization/human-identity-attestation.js';
 import type { OrgMember } from '../../src/control-plane/schema/org-member.js';
+import type { AgentDbAdapterConfig } from '../../src/control-plane/store/agentdb-adapter.js';
 
 /** Throwaway Ed25519 PKCS8 PEM — test-only, generated once for this fixture, no relation to any real secret. */
 const TEST_ISSUER_PRIVATE_KEY_PEM =
@@ -28,6 +36,88 @@ export const unadmittedIssuerConfig: IssuerKeyConfig = {
 /** Real, valid `ActorAuthorization` for `member` — signed by the test issuer, admitting only the test issuer's key. */
 export async function credentialFor(member: OrgMember, opts?: { ttlSeconds?: number }): Promise<ActorAuthorization> {
   const credential = await mintActorCredential(member.id, member.companyId, opts, testIssuerConfig);
+  const admittedIssuerKeys = await resolveAdmittedIssuerKeys(testIssuerConfig);
+  return { credential, admittedIssuerKeys };
+}
+
+/**
+ * Test-only Ed25519 keypair standing in for an external human-identity
+ * attester (e.g. a Cognitum-side identity-resolution service) — see
+ * `human-identity-attestation.ts`. Not the ruClip issuer key above; a real
+ * deployment's attester and issuer keys belong to different systems.
+ */
+const TEST_ATTESTER_PRIVATE_KEY_PEM =
+  '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIOTpG5rV5jJPGl1OTRSdvNs5SfZ0BbZ4EJZmxr77nDPI\n-----END PRIVATE KEY-----\n';
+
+/** A second, never-admitted attester keypair — for "signed by an unadmitted attester" tests. */
+export const unadmittedAttesterPrivateKeyPem =
+  '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIA1D7Q4yQvV3z0y2m2u1x3n4M8xkQwYyMv1n0F9c6qzu\n-----END PRIVATE KEY-----\n';
+
+function attesterPublicKeyDerHex(privateKeyPem: string): string {
+  const privateKey = createPrivateKey(privateKeyPem);
+  return createPublicKey(privateKey).export({ type: 'spki', format: 'der' }).toString('hex');
+}
+
+export const testAttesterPublicKeyDerHex = attesterPublicKeyDerHex(TEST_ATTESTER_PRIVATE_KEY_PEM);
+
+/** `resolveAdmittedAttesterKeys`-compatible set admitting only the test attester's key. */
+export const testAdmittedAttesterKeys = resolveAdmittedAttesterKeys({ admittedKeys: new Set([testAttesterPublicKeyDerHex]) });
+
+interface RadioMoeCanonicalModule {
+  canonicalBytes(value: unknown): Buffer;
+}
+
+/** Real `radio-moe` `canonicalBytes` (a real devDependency, not reimplemented) — loaded the exact same required-not-optional dynamic-import way the src modules load it. */
+async function loadCanonicalBytes(): Promise<(value: unknown) => Buffer> {
+  const mod = (await import('radio-moe')) as unknown as RadioMoeCanonicalModule;
+  return mod.canonicalBytes;
+}
+
+/**
+ * Mints a real, validly-signed `HumanIdentityAttestation` using the given
+ * attester private key (defaults to the admitted test attester). `humanIdentityRef`
+ * defaults to `member.identityRef` — pass an explicit value to construct a
+ * deliberately mismatched attestation for the identity-binding tests.
+ * Mirrors `credential-issuer.ts`'s own reproduction of radio-moe's real
+ * `signFrame` contract: sign `canonicalBytes({...frame, signature: ''})`.
+ */
+export async function humanAttestationFor(
+  member: Pick<OrgMember, 'id' | 'companyId' | 'identityRef'>,
+  opts?: { ttlSeconds?: number; humanIdentityRef?: string; attesterPrivateKeyPem?: string },
+): Promise<HumanIdentityAttestation> {
+  const privateKey = createPrivateKey(opts?.attesterPrivateKeyPem ?? TEST_ATTESTER_PRIVATE_KEY_PEM);
+  const attesterKeyDerHex = createPublicKey(privateKey).export({ type: 'spki', format: 'der' }).toString('hex');
+  const canonicalBytes = await loadCanonicalBytes();
+
+  const now = new Date();
+  const ttlSeconds = opts?.ttlSeconds ?? 15 * 60;
+  const issuedAt = now.toISOString();
+  const expiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
+  const nonce = randomUUID();
+  const humanIdentityRef = opts?.humanIdentityRef ?? member.identityRef;
+
+  const unsignedFields = { orgMemberId: member.id, companyId: member.companyId, humanIdentityRef, issuedAt, expiresAt, nonce };
+  const signingBytes = canonicalBytes({ ...attestationFrame(unsignedFields), signature: '' });
+  const signature = edSign(null, signingBytes, privateKey).toString('hex');
+  return { ...unsignedFields, signature, attesterPublicKeyDerHex: attesterKeyDerHex };
+}
+
+/**
+ * Mints a real `ActorCredential` for `member` via the full attestation ->
+ * mint pipeline (`mintHumanActorCredential`), using the test attester and
+ * test issuer keys. This is the ONLY fixture helper that produces a
+ * credential carrying the human-attestation provenance marker — a
+ * credential from `credentialFor(humanMember)` above does NOT carry it
+ * (mirrors production: only `mintHumanActorCredential` ever writes that
+ * marker).
+ */
+export async function humanCredentialFor(
+  member: OrgMember,
+  config: AgentDbAdapterConfig,
+  opts?: { ttlSeconds?: number },
+): Promise<ActorAuthorization> {
+  const attestation = await humanAttestationFor(member, opts);
+  const credential = await mintHumanActorCredential(attestation, testAdmittedAttesterKeys, opts, testIssuerConfig, config);
   const admittedIssuerKeys = await resolveAdmittedIssuerKeys(testIssuerConfig);
   return { credential, admittedIssuerKeys };
 }


### PR DESCRIPTION
## Summary

Closes the human-issuance gap `docs/design/ACTOR-IDENTITY-VERIFICATION.md`
§4 named and deliberately deferred ("Issuance for `kind: 'human'`
OrgMembers — NOT solved here, named honestly rather than papered over").
Gives ruClip a way to mint a real, signed `ActorCredential` for a
`kind: 'human'` OrgMember from a verified Cognitum identity, so a human can
now actually approve/reject an issue through `applyApprovalTransition` —
confirmed end to end by a full-pipeline test, not just at the unit level.

- **`docs/design/HUMAN-CREDENTIAL-ISSUANCE.md`** (new): the design —
  ground-truth investigation of `credential-issuer.ts`'s actual trust
  model, `cognitum-one/comms` ADR-0009 (cited as prior art for the
  Ed25519/nonce *strategy* only — its own byte contract is for AgentBBS
  room identity, a different job), and `cognitum-one/slack` ADR-0002/
  ADR-0015 (the real, shipped Cognitum identity source — a Slack `user_id`
  resolved via a verified `@cognitum.one` mailbox — that a
  `HumanIdentityAttestation` is shaped to carry via `identityRef`, with
  zero Slack/Firebase/Cognitum imports into ruClip itself — the substrate
  stays ruvnet-only).
- **`src/control-plane/authorization/human-identity-attestation.ts`**
  (new): `HumanIdentityAttestation`, `attestationFrame` (same real
  `radio-moe` `AgentFrame`/`canonicalBytes`/`verifyFrame` primitive
  `actor-credential.ts` already uses — no second signing mechanism),
  `verifyHumanIdentityAttestation` (expiry/attester-admission/signature/
  nonce-replay), `resolveAdmittedAttesterKeys` (pluggable — explicit key
  set, or an env-var fallback; deliberately NOT a GCP Secret Manager
  integration, since an attester's private key belongs to an external
  system ruClip never holds), and `mintHumanActorCredential` (verifies the
  attestation, cross-checks `humanIdentityRef` against the target
  OrgMember's own persisted `identityRef`, rejects non-human targets, then
  mints via the existing `mintActorCredential` — same durable issuer key
  agent issuance already uses).
- **`src/control-plane/authorization/actor-credential.ts`**: a real
  security gap found while designing this (see the design doc §1 point 1)
  — without a structural marker, "only mint a human credential after a
  real attestation" would be pure caller discipline, exactly as bypassable
  as it already is for agent issuance by anyone holding the durable issuer
  key. Fixed with an AgentDB-backed provenance marker
  (`humanAttestedCredentialMarkerKey`) that `mintHumanActorCredential` is
  the ONLY code path that ever writes, keyed by the credential's own
  nonce. `resolveVerifiedActor` now requires that marker before
  authorizing a `kind: 'human'` actor — every credential minted any other
  way (including a bare `mintActorCredential` call naming a human
  `orgMemberId`) stays blocked exactly as §4 originally locked down.

## The attestation contract, in five lines

```
orgMemberId, companyId, humanIdentityRef (e.g. "slack:U0BQJNHH7L3"),
issuedAt, expiresAt (15 min default TTL), nonce (single-use replay guard,
own AgentDB namespace), signature (radio-moe signFrame over
attestationFrame), attesterPublicKeyDerHex (checked against a
caller-supplied admitted-attester set before the signature is trusted).
```

## Test plan

- `npm ci && npm test` before any change: **209/209** passing (baseline).
- `npm test` after: **222/222** passing (13 new tests), `tsc --strict`
  clean, real installed `radio-moe@0.3.1` used throughout (no mocks for
  signing/verification — only the AgentDB bridge is mocked).
- New coverage (`tests/control-plane/human-identity-attestation.test.ts`):
  forged attestation (tampered post-signing) rejected; unadmitted attester
  key rejected even when internally valid; expired attestation rejected;
  replayed attestation nonce rejected; missing target OrgMember rejected;
  non-human target rejected; `humanIdentityRef`/`OrgMember.identityRef`
  mismatch rejected; the provenance-marker regression (blocked without it,
  authorized with it); two full-pipeline tests driving a real human
  OrgMember through `applyApprovalTransition`'s `'approve'` action end to
  end — both the positive case and a negative case confirming a bare
  `mintActorCredential` credential for the same human still fails the
  whole orchestration function.
- Existing `tests/control-plane/actor-identity-verification.test.ts`'s
  human-block test still passes unchanged in behavior (updated docstring
  only, to cross-reference the new path) — the fail-closed default is
  unmodified for every credential that doesn't go through the new
  attestation path.

## What's still open (named, not hidden)

No producer of a `HumanIdentityAttestation` exists yet — no login/
dashboard flow calls `mintHumanActorCredential`. This narrows Phase 2's
remaining prerequisite (`docs/PLAN.md`) to "produce one signed statement"
rather than "solve human authentication from scratch."
`setInteractionProfileConsent`'s residual `actor.id` forgery risk (§4's
narrowed exception) is unchanged — deliberately out of this slice's scope.

Refs #1 (Coordination: ruClip → Cognitum integration — bridge, identity,
boards).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01MND33UDrtWPRH851k9w8M3