### PR TITLE
fix(ci): run on Node 22 — node --test glob needs Node ≥21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm install --no-audit --no-fund || true
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
CI's `scaffold-check` fails on every run before any test executes: `npm test` passes a quoted glob (`"dist/**/*.test.js"`) to `node --test`, whose native glob support arrived in Node 21 — the runner is pinned to Node 20, so it looks for that literal path and exits 1. Seen on PR #2 (run 33578574610); `main` hits it identically. Because the job dies there, the `harness:bench-verify` hard gate added in de5e13f never actually runs on CI.

One-line fix: `setup-node` → Node 22, the version the suite is developed and verified on (222/222 locally on PR #2's head, 209/209 on main).

## Test plan
- [x] Root-caused from the failing run log, not guessed
- [ ] CI green on this PR (proves the fix)
- [ ] Re-run PR #2's CI after merge — should go green with no code change there

Refs #1 (coordination).

Co-Authored-By: claude-flow <ruv@ruv.net>
Claude-Session: https://claude.ai/code/session_01MND33UDrtWPRH851k9w8M3

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)