### PR TITLE
fix(store): recallByKey pages wide so the exact key survives sibling growth (#5)

### DIFF
--- a/src/control-plane/store/agentdb-adapter.test.ts
+++ b/src/control-plane/store/agentdb-adapter.test.ts
@@ -213,6 +213,53 @@ test('recallCompany filters hierarchical-recall results to an exact key match', 
   assert.deepEqual(recalled, stored);
 });
 
+test('recallCompany finds the exact key even when many sibling records share its prefix (ruvnet/ruClip#5)', async () => {
+  // A seeded company quickly has more than ten records under ruclip:company:<id>
+  // (members, goal, issues, heartbeats). The old topK:10 page could omit the exact key.
+  const stored: Company = {
+    id: 'co-1',
+    name: 'Acme',
+    primaryGoalId: null,
+    budget: { total: 1000, spent: 0, currency: 'USD', period: '2026-09', hardStopThreshold: 0.9 },
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const siblings = Array.from({ length: 11 }, (_, i) => ({
+    key: `ruclip:company:co-1:org-member:om-${i}`,
+    value: JSON.stringify({ id: `om-${i}` }),
+  }));
+  const { calls, config } = mockBridge({
+    'agentdb_hierarchical-recall': () => ({
+      results: [...siblings, { key: 'ruclip:company:co-1', value: JSON.stringify(stored) }],
+    }),
+  });
+  const recalled = await recallCompany('co-1', config);
+  assert.deepEqual(recalled, stored);
+  const recallCall = calls.find((c) => c.toolName === 'agentdb_hierarchical-recall');
+  assert.ok((recallCall?.args.topK as number) >= 12, 'first recall page must be wider than the sibling count');
+});
+
+test('recallCompany widens the page when the first one is full without a match, and stops on a short page', async () => {
+  let pages = 0;
+  const { calls, config } = mockBridge({
+    'agentdb_hierarchical-recall': (args: Record<string, unknown>) => {
+      pages += 1;
+      const topK = args.topK as number;
+      // First page: completely full of non-matching siblings. Second page: short, still no match.
+      const count = pages === 1 ? topK : 3;
+      return {
+        results: Array.from({ length: count }, (_, i) => ({ key: `ruclip:company:co-1:issue:i-${i}`, value: '{}' })),
+      };
+    },
+  });
+  const recalled = await recallCompany('co-1', config);
+  assert.equal(recalled, null);
+  const topKs = calls.filter((c) => c.toolName === 'agentdb_hierarchical-recall').map((c) => c.args.topK as number);
+  assert.equal(topKs.length, 2, 'one widening retry, then stop on the short page');
+  assert.ok(topKs[1]! > topKs[0]!, 'second page must be wider than the first');
+});
+
 test('recallCompany returns null when no exact key match is found', async () => {
   const { config } = mockBridge({
     'agentdb_hierarchical-recall': () => ({ results: [] }),

--- a/src/control-plane/store/agentdb-adapter.ts
+++ b/src/control-plane/store/agentdb-adapter.ts
@@ -193,23 +193,39 @@ async function deleteFromTier(key: string, tier: MemoryTier, config?: AgentDbAda
  * over `query`, not an exact-key get — we search with the key as the query
  * and defensively keep only a result whose own key matches exactly.
  */
+const RECALL_BY_KEY_PAGE_SIZES = [200, 1000] as const;
+
 async function recallByKey<T>(
   key: string,
   tier: MemoryTier | undefined,
   config?: AgentDbAdapterConfig,
 ): Promise<T | null> {
-  const result = await callTool<{ results?: Array<{ key?: string; id?: string; value?: string }> }>(
-    'agentdb_hierarchical-recall',
-    { query: key, tier, topK: 10 },
-    config,
-  );
-  const match = (result.results ?? []).find((r) => r.key === key || r.id === key);
-  if (!match || typeof match.value !== 'string') return null;
-  try {
-    return JSON.parse(match.value) as T;
-  } catch {
-    return null;
+  // agentdb_hierarchical-recall is a similarity/lexical search, not an exact-key read: the
+  // exact key is only somewhere in the result page. On a real bridge a company with more
+  // than ten sibling records (members, issues, heartbeats all share the company prefix)
+  // pushed the exact key out of a topK:10 page, so recallCompany() returned null and every
+  // caller that starts with "recall the company" silently did nothing (ruvnet/ruClip#5).
+  // Page wide first, then widen once more before giving up.
+  for (const topK of RECALL_BY_KEY_PAGE_SIZES) {
+    const result = await callTool<{ results?: Array<{ key?: string; id?: string; value?: string }> }>(
+      'agentdb_hierarchical-recall',
+      { query: key, tier, topK },
+      config,
+    );
+    const results = result.results ?? [];
+    const match = results.find((r) => r.key === key || r.id === key);
+    if (match) {
+      if (typeof match.value !== 'string') return null;
+      try {
+        return JSON.parse(match.value) as T;
+      } catch {
+        return null;
+      }
+    }
+    // A short page means the store has no more candidates; a full page means widen.
+    if (results.length < topK) return null;
   }
+  return null;
 }
 
 // --- Causal edges (DOMAIN-MODEL.md §2.3) ----------------------------------


### PR DESCRIPTION
Fixes the third finding in #5.

`recallByKey` asked `agentdb_hierarchical-recall` for `topK: 10` and looked for the exact key in that page. On a real bridge a seeded company (6 members, 1 goal, 3 issues, heartbeats) has more than ten records under `ruclip:company:<id>`, so `recallCompany()` returned `null` and everything downstream of "recall the company" silently no-op'd — including `persistHeartbeatSchedule`'s own `recallIssue`, which made issue heartbeats impossible to create once the company grew.

- Page 200 first, widen once to 1000 if the page is full and unmatched, stop on a short page.
- Two regression tests (exact key after eleven siblings; widen-then-stop). The in-memory fake returned the exact key regardless of `topK`, which is why CI never caught it.
- 313/313.

Verified live in cognitum-one/ruclip (PR #4 head 6e9515b + this change): `GET /companies/cognitum` resolves and heartbeat due-discovery sees all four schedules.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)