### PR TITLE
fix(store): fail loudly on success:false; company-scoped keys under the 128-char bridge cap; transition listing query (#5)

### DIFF
--- a/docs/design/APPROVAL-GATE.md
+++ b/docs/design/APPROVAL-GATE.md
@@ -210,7 +210,7 @@ Steps:
    carries its own witness pointer rather than needing a follow-up write.
 3. Persist the `ApprovalTransition` record itself — same key/tier pattern
    as `Comment` (§2.2 of DOMAIN-MODEL.md): `ruclip:company:{companyId}:
-   goal:{goalId}:issue:{issueId}:approval-transition:{transitionId}`,
+   approval-transition:{transitionId}` (company-scoped; record carries issueId — bridge keys are capped at 128 chars),
    stored at the issue's *current* tier (before this call's status change,
    if any — approval transitions don't change `status`, so this is always
    the issue's existing tier), immutable, never updated after write.

--- a/docs/design/DOMAIN-MODEL.md
+++ b/docs/design/DOMAIN-MODEL.md
@@ -162,7 +162,7 @@ ruclip:company:{companyId}
 ruclip:company:{companyId}:org-member:{orgMemberId}
 ruclip:company:{companyId}:goal:{goalId}
 ruclip:company:{companyId}:goal:{goalId}:issue:{issueId}
-ruclip:company:{companyId}:goal:{goalId}:issue:{issueId}:comment:{commentId}
+ruclip:company:{companyId}:comment:{commentId}            (record carries issueId; keys are capped at 128 chars by the bridge)
 ```
 
 ### 2.3 Causal edges

--- a/docs/design/HEARTBEATS-AND-COMMS.md
+++ b/docs/design/HEARTBEATS-AND-COMMS.md
@@ -184,8 +184,8 @@ Keying, following the existing `companyKey`/`goalKey`/`issueKey`/
 `commentKey`/`approvalTransitionKey` convention in `store/agentdb-adapter.ts`:
 
 ```
-ruclip:company:{companyId}:goal:{goalId}:heartbeat:{heartbeatId}                       (target.kind: 'goal')
-ruclip:company:{companyId}:goal:{goalId}:issue:{issueId}:heartbeat:{heartbeatId}       (target.kind: 'issue')
+ruclip:company:{companyId}:heartbeat:{heartbeatId}   (both target kinds; `target` inside the record carries goalId/issueId —
+                                                      the bridge caps keys at 128 chars, so schedules are not nested under goal/issue)
 ```
 
 Hierarchical-store tier: `working` while `status === 'active' | 'paused'`

--- a/src/control-plane/store/agentdb-adapter.test.ts
+++ b/src/control-plane/store/agentdb-adapter.test.ts
@@ -13,6 +13,8 @@ import {
   recallCompany,
   AgentDbBridgeError,
   type AgentDbAdapterConfig,
+  heartbeatKey,
+  MAX_AGENTDB_KEY_LENGTH,
 } from './agentdb-adapter.js';
 import type { Company } from '../schema/company.js';
 import type { OrgMember } from '../schema/org-member.js';
@@ -96,7 +98,7 @@ test('keying scheme matches DOMAIN-MODEL.md §2.2', () => {
   assert.equal(issueKey('co-1', 'goal-1', 'issue-1'), 'ruclip:company:co-1:goal:goal-1:issue:issue-1');
   assert.equal(
     commentKey('co-1', 'goal-1', 'issue-1', 'comment-1'),
-    'ruclip:company:co-1:goal:goal-1:issue:issue-1:comment:comment-1',
+    'ruclip:company:co-1:comment:comment-1',
   );
 });
 
@@ -266,4 +268,33 @@ test('recallCompany returns null when no exact key match is found', async () => 
   });
   const recalled = await recallCompany('missing-co', config);
   assert.equal(recalled, null);
+});
+
+test('storeAtTier fails loudly when the bridge answers success:false inside a normal result (key too long)', async () => {
+  const { config } = mockBridge({
+    'agentdb_hierarchical-store': () => ({ success: false, error: 'key exceeds 128 characters' }),
+  });
+  const company: Company = {
+    id: 'co-1',
+    name: 'Acme',
+    primaryGoalId: null,
+    budget: { total: 1000, spent: 0, currency: 'USD', period: '2026-09', hardStopThreshold: 0.9 },
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  };
+  await assert.rejects(() => persistCompany(company, config), /refused key .*key exceeds 128 characters/);
+});
+
+test('heartbeat, comment and approval-transition keys are company-scoped and stay under the bridge cap with long ids', () => {
+  const companyId = 'cognitum';
+  const goalId = 'goal-ruclip-launch';
+  const issueId = 'issue-heartbeat-scheduler-loop';
+  const hb = heartbeatKey(companyId, { kind: 'issue', goalId, issueId }, 'hb-issue-issue-heartbeat-scheduler-loop');
+  assert.equal(hb, 'ruclip:company:cognitum:heartbeat:hb-issue-issue-heartbeat-scheduler-loop');
+  assert.ok(hb.length <= MAX_AGENTDB_KEY_LENGTH);
+  const cm = commentKey(companyId, goalId, 'issue-a77be3cc-3cd6-455f-bf65-606f87f439ef', 'comment-10cb0f00-22fc-4156-b64c-ebca97472537');
+  assert.equal(cm, 'ruclip:company:cognitum:comment:comment-10cb0f00-22fc-4156-b64c-ebca97472537');
+  assert.ok(cm.length <= MAX_AGENTDB_KEY_LENGTH);
+  assert.throws(() => goalKey(companyId, 'g'.repeat(120)), /exceeds 128 characters/);
 });

--- a/src/control-plane/store/agentdb-adapter.ts
+++ b/src/control-plane/store/agentdb-adapter.ts
@@ -123,37 +123,56 @@ export function companyKey(companyId: string): string {
 export function orgMemberKey(companyId: string, orgMemberId: string): string {
   assertSafeId(companyId, 'companyId');
   assertSafeId(orgMemberId, 'orgMemberId');
-  return `ruclip:company:${companyId}:org-member:${orgMemberId}`;
+  return assertKeyFits(`ruclip:company:${companyId}:org-member:${orgMemberId}`);
 }
 export function goalKey(companyId: string, goalId: string): string {
   assertSafeId(companyId, 'companyId');
   assertSafeId(goalId, 'goalId');
-  return `ruclip:company:${companyId}:goal:${goalId}`;
+  return assertKeyFits(`ruclip:company:${companyId}:goal:${goalId}`);
 }
 export function issueKey(companyId: string, goalId: string, issueId: string): string {
   assertSafeId(companyId, 'companyId');
   assertSafeId(goalId, 'goalId');
   assertSafeId(issueId, 'issueId');
-  return `ruclip:company:${companyId}:goal:${goalId}:issue:${issueId}`;
+  return assertKeyFits(`ruclip:company:${companyId}:goal:${goalId}:issue:${issueId}`);
 }
-export function commentKey(companyId: string, goalId: string, issueId: string, commentId: string): string {
+/**
+ * The bridge's hierarchical store rejects keys longer than this (observed live:
+ * `{"success": false, "error": "key exceeds 128 characters"}` inside a non-error
+ * result). Nesting comment/approval-transition/heartbeat keys under
+ * company→goal→issue crossed it with ordinary ids, so those three are keyed at
+ * company level; the record itself carries goalId/issueId/target for scoping.
+ */
+export const MAX_AGENTDB_KEY_LENGTH = 128;
+function assertKeyFits(key: string): string {
+  if (key.length > MAX_AGENTDB_KEY_LENGTH) {
+    throw new AgentDbBridgeError(
+      `AgentDB key exceeds ${MAX_AGENTDB_KEY_LENGTH} characters (${key.length}): '${key}' — shorten the ids`,
+    );
+  }
+  return key;
+}
+export function commentKey(companyId: string, _goalId: string, _issueId: string, commentId: string): string {
   assertSafeId(commentId, 'commentId');
-  return `${issueKey(companyId, goalId, issueId)}:comment:${commentId}`;
+  return assertKeyFits(`${companyKey(companyId)}:comment:${commentId}`);
 }
 export function approvalTransitionKey(
   companyId: string,
-  goalId: string,
-  issueId: string,
+  _goalId: string,
+  _issueId: string,
   transitionId: string,
 ): string {
   assertSafeId(transitionId, 'transitionId');
-  return `${issueKey(companyId, goalId, issueId)}:approval-transition:${transitionId}`;
+  return assertKeyFits(`${companyKey(companyId)}:approval-transition:${transitionId}`);
 }
-/** HEARTBEATS-AND-COMMS.md §1 keying — mirrors goalKey/issueKey's target-shaped nesting. */
+/** HEARTBEATS-AND-COMMS.md §1 keying — company-scoped; the schedule's `target` carries goal/issue. */
 export function heartbeatKey(companyId: string, target: HeartbeatTarget, heartbeatId: string): string {
   assertSafeId(heartbeatId, 'heartbeatId');
-  const base = target.kind === 'issue' ? issueKey(companyId, target.goalId, target.issueId) : goalKey(companyId, target.goalId);
-  return `${base}:heartbeat:${heartbeatId}`;
+  if (target.kind === 'issue') {
+    assertSafeId(target.issueId, 'issueId');
+  }
+  assertSafeId(target.goalId, 'goalId');
+  return assertKeyFits(`${companyKey(companyId)}:heartbeat:${heartbeatId}`);
 }
 
 /** AUTOGENOUS-RUNTIME-GOVERNANCE.md §6 keying — mirrors heartbeatKey's company-scoped nesting. */
@@ -181,11 +200,29 @@ async function storeAtTier(
   tier: MemoryTier,
   config?: AgentDbAdapterConfig,
 ): Promise<void> {
-  await callTool('agentdb_hierarchical-store', { key, value: JSON.stringify(value), tier }, config);
+  const result = await callTool<{ success?: boolean; error?: string }>(
+    'agentdb_hierarchical-store',
+    { key, value: JSON.stringify(value), tier },
+    config,
+  );
+  assertToolSucceeded('agentdb_hierarchical-store', key, result);
+}
+
+/**
+ * The bridge reports some failures (key too long, backend refusal) as
+ * `{ success: false, error }` inside an ordinary result, not as a JSON-RPC
+ * error — so a write can "succeed" while nothing is stored. Treat that as
+ * a failure here, once, for every store/delete.
+ */
+function assertToolSucceeded(tool: string, key: string, result: { success?: boolean; error?: string } | null | undefined): void {
+  if (result && result.success === false) {
+    throw new AgentDbBridgeError(`AgentDB tool '${tool}' refused key '${key}': ${result.error ?? 'unknown error'}`);
+  }
 }
 
 async function deleteFromTier(key: string, tier: MemoryTier, config?: AgentDbAdapterConfig): Promise<void> {
-  await callTool('agentdb_hierarchical-delete', { key, tier }, config);
+  const result = await callTool<{ success?: boolean; error?: string }>('agentdb_hierarchical-delete', { key, tier }, config);
+  assertToolSucceeded('agentdb_hierarchical-delete', key, result);
 }
 
 /**
@@ -736,13 +773,16 @@ export async function listApprovalTransitionsForCompany(
   assertSafeId(companyId, 'companyId');
   const transitions: ApprovalTransition[] = [];
   for (const tier of ['working', 'episodic'] as const) {
-    const result = await callTool<{ results?: Array<{ value?: string }> }>(
+    const result = await callTool<{ results?: Array<{ key?: string; value?: string }> }>(
       'agentdb_hierarchical-recall',
-      { query: `ruclip:company:${companyId} approval-transition`, tier, topK: 200 },
+      { query: companyKey(companyId), tier, topK: 500 },
       config,
     );
     for (const r of result.results ?? []) {
+      // A similarity query with extra words returned nothing on a real bridge;
+      // the bare company prefix returns the company's records, filtered by key.
       if (typeof r.value !== 'string') continue;
+      if (typeof r.key === 'string' && !r.key.includes(':approval-transition:')) continue;
       try {
         const parsed = JSON.parse(r.value) as Partial<ApprovalTransition>;
         if (parsed && typeof parsed.issueId === 'string' && typeof parsed.actorId === 'string' && typeof parsed.action === 'string') {

--- a/tests/control-plane/actor-credential-authorization-gaps.test.ts
+++ b/tests/control-plane/actor-credential-authorization-gaps.test.ts
@@ -160,7 +160,7 @@ test(
     const issue = baseIssue();
     const pausedSchedule = baseSchedule({ status: 'paused' });
     const issueKeyStr = 'ruclip:company:co-1:goal:goal-1:issue:issue-1';
-    const scheduleKeyStr = `${issueKeyStr}:heartbeat:hb-1`;
+    const scheduleKeyStr = `ruclip:company:co-1:heartbeat:hb-1`;
     const { calls, config } = mockBridge({
       'agentdb_hierarchical-recall': (args) => {
         if (args.query === scheduleKeyStr) {

--- a/tests/control-plane/agentdb-adapter.test.ts
+++ b/tests/control-plane/agentdb-adapter.test.ts
@@ -307,7 +307,7 @@ test('persistComment stores at the tier passed in for the parent issue', async (
   });
   const comment: Comment = { id: 'comment-1', issueId: 'issue-1', authorId: 'om-1', body: 'hi', createdAt: now };
   await persistComment('co-1', 'goal-1', comment, 'working', config);
-  assert.equal(calls[0]?.args.key, 'ruclip:company:co-1:goal:goal-1:issue:issue-1:comment:comment-1');
+  assert.equal(calls[0]?.args.key, 'ruclip:company:co-1:comment:comment-1');
   assert.equal(calls[0]?.args.tier, 'working');
 });
 

--- a/tests/control-plane/approval-gate.test.ts
+++ b/tests/control-plane/approval-gate.test.ts
@@ -402,7 +402,7 @@ test('applyApprovalTransition (submit, no witness): persists the transition, upd
     (c) => c.toolName === 'agentdb_hierarchical-store' && (c.args.key as string).includes(':approval-transition:'),
   );
   assert.ok(transitionStoreCall, 'expected the ApprovalTransition record to be persisted');
-  assert.equal(transitionStoreCall!.args.key, `${issueKeyStr}:approval-transition:${result.transition.id}`);
+  assert.equal(transitionStoreCall!.args.key, `ruclip:company:co-1:approval-transition:${result.transition.id}`);
 
   const issueStoreCall = calls.find(
     (c) => c.toolName === 'agentdb_hierarchical-store' && c.args.key === issueKeyStr,

--- a/tests/control-plane/authorization-trust-boundary.test.ts
+++ b/tests/control-plane/authorization-trust-boundary.test.ts
@@ -67,7 +67,7 @@ import type { ApprovalTransition } from '../../src/control-plane/schema/approval
 const now = '2026-09-01T00:00:00.000Z';
 const issueKeyStr = 'ruclip:company:co-1:goal:goal-1:issue:issue-1';
 const orgMemberKeyStr = 'ruclip:company:co-1:org-member:om-approver';
-const submitTransitionKeyStr = `${issueKeyStr}:approval-transition:transition-submit`;
+const submitTransitionKeyStr = `ruclip:company:co-1:approval-transition:transition-submit`;
 
 function baseIssue(overrides: Partial<Issue> = {}): Issue {
   return {

--- a/tests/control-plane/claims-authorization.test.ts
+++ b/tests/control-plane/claims-authorization.test.ts
@@ -273,7 +273,7 @@ test(
     'persistIssue directly and bypassing applyApprovalTransition entirely',
   async () => {
     const submitterId = 'om-submitter';
-    const submitTransitionKey = `${issueKeyStr}:approval-transition:transition-submit`;
+    const submitTransitionKey = `ruclip:company:co-1:approval-transition:transition-submit`;
     const persistedSubmitTransition = baseTransition({
       id: 'transition-submit',
       action: 'submit',
@@ -343,7 +343,7 @@ test(
 
 test('recallApprovalTransition (used by Guard C\'s self-approval recheck) round-trips a stored transition by key', async () => {
   const transition = baseTransition({ id: 'transition-submit' });
-  const key = `${issueKeyStr}:approval-transition:transition-submit`;
+  const key = `ruclip:company:co-1:approval-transition:transition-submit`;
   const { config } = mockBridge({
     'agentdb_hierarchical-recall': (args) =>
       args.tier === 'working' && args.query === key

--- a/tests/control-plane/heartbeats-and-comms.test.ts
+++ b/tests/control-plane/heartbeats-and-comms.test.ts
@@ -132,14 +132,14 @@ function activeClaimFor(actor: OrgMember, issueId: string) {
 
 // --- heartbeatKey ------------------------------------------------------------
 
-test('heartbeatKey nests under the goal key for a goal target and the issue key for an issue target', () => {
+test('heartbeatKey is company-scoped for both goal and issue targets (bridge caps keys at 128 chars)', () => {
   assert.equal(
     heartbeatKey('co-1', { kind: 'goal', goalId: 'goal-1' }, 'hb-1'),
-    'ruclip:company:co-1:goal:goal-1:heartbeat:hb-1',
+    'ruclip:company:co-1:heartbeat:hb-1',
   );
   assert.equal(
     heartbeatKey('co-1', { kind: 'issue', goalId: 'goal-1', issueId: 'issue-1' }, 'hb-1'),
-    'ruclip:company:co-1:goal:goal-1:issue:issue-1:heartbeat:hb-1',
+    'ruclip:company:co-1:heartbeat:hb-1',
   );
 });
 


### PR DESCRIPTION
Found by running the Cognitum control plane (cognitum-one/ruclip PR #4) against a real ruflo bridge.

**1. Silent write failure.** `agentdb_hierarchical-store` returns `{"success": false, "error": "key exceeds 128 characters"}` as a *normal* result. `storeAtTier` never checked it, so `persistHeartbeatSchedule` reported success for every issue heartbeat while none were stored (the seed counted 4 created; the bridge held 1). Store/delete now throw `AgentDbBridgeError` on `success: false`.

**2. Keys over the bridge cap.** Nesting comment / approval-transition / heartbeat keys under company→goal→issue produced 131-char keys with ordinary ids. They're now company-scoped; the record carries `goalId`/`issueId`/`target`. All key builders assert the 128-char cap.

**3. Transition listing.** `"<company prefix> approval-transition"` as a recall query returns nothing on a real bridge (same class as the `recallByKey` fix in #6). Now: bare company prefix + key filter.

Docs updated (HEARTBEATS-AND-COMMS §1, DOMAIN-MODEL §2.2, APPROVAL-GATE). 315/315.

Closes the remaining items in #5.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)